### PR TITLE
Refactor Code to pass Sonar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ java {
 project.ext.excludesFromTestCoverage = ['**/DetectDownloadStrategy.java', '**/DetectPipelineStep.java', '**/DetectPostBuildStep.java', '**/DetectAirGapInstallation.java']
 
 group = 'com.blackducksoftware.integration'
-version = '10.0.1-SNAPSHOT'
+version = '10.0.1-SIGQA1'
 description = 'Black Duck Detect for Jenkins'
 
 apply plugin: 'com.blackduck.integration.solution'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ java {
 project.ext.excludesFromTestCoverage = ['**/DetectDownloadStrategy.java', '**/DetectPipelineStep.java', '**/DetectPostBuildStep.java', '**/DetectAirGapInstallation.java']
 
 group = 'com.blackducksoftware.integration'
-version = '10.0.1-SIGQA1'
+version = '10.0.1-SIGQA2-SNAPSHOT'
 description = 'Black Duck Detect for Jenkins'
 
 apply plugin: 'com.blackduck.integration.solution'

--- a/src/main/java/com/blackduck/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategy.java
+++ b/src/main/java/com/blackduck/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategy.java
@@ -121,7 +121,11 @@ public class DetectAirGapJarStrategy extends DetectExecutionStrategy {
             try {
                 return findAirGapJar(airGapBaseDir, foundAirGapJars);
             } catch (Exception e) {
-                return findAirGapJar(airGapBaseDir, foundFallbackJars);
+                if(foundAirGapJars == null || foundAirGapJars.length == 0) {
+                    return findAirGapJar(airGapBaseDir, foundFallbackJars);
+                } else {
+                    throw e;
+                }
             }
         }
 

--- a/src/main/java/com/blackduck/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategy.java
+++ b/src/main/java/com/blackduck/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategy.java
@@ -118,28 +118,28 @@ public class DetectAirGapJarStrategy extends DetectExecutionStrategy {
             FileFilter backUpFileFilter = file -> file.getName().startsWith(FALLBACK_DETECT_JAR_PREFIX) && file.getName().endsWith(DETECT_JAR_SUFFIX);
             File[] foundFallbackJars = new File(airGapBaseDir).listFiles(backUpFileFilter);
 
-            if ((foundAirGapJars == null || foundAirGapJars.length == 0) && (foundFallbackJars == null || foundFallbackJars.length == 0)) {
+            try {
+                return findAirGapJar(airGapBaseDir, foundAirGapJars);
+            } catch (Exception e) {
+                return findAirGapJar(airGapBaseDir, foundFallbackJars);
+            }
+        }
+
+
+        private String findAirGapJar(String airGapBaseDir, File[] foundJars) throws DetectJenkinsException {
+            if (foundJars == null || foundJars.length == 0) {
                 throw new DetectJenkinsException(String.format(
                         "Expected 1 jar from Detect Air Gap tool installation at <%s> and did not find any. Check your Jenkins plugin and tool configuration.",
                         airGapBaseDir
                 ));
-            } else if ((foundAirGapJars != null && foundAirGapJars.length > 1) || (foundFallbackJars != null && foundFallbackJars.length > 1)) {
+            } else if (foundJars.length > 1) {
                 throw new DetectJenkinsException(
                         String.format(
                                 "Expected 1 jar from Detect Air Gap tool installation at <%s> and instead found multiple jars. Check your Jenkins plugin and tool configuration.",
                                 airGapBaseDir
                         ));
             } else {
-                if (foundAirGapJars != null && foundAirGapJars.length == 1) {
-                    return foundAirGapJars[0].toString();
-                } else if(foundFallbackJars != null && foundFallbackJars.length == 1) {
-                    return foundFallbackJars[0].toString();
-                } else {
-                    throw new DetectJenkinsException(String.format(
-                            "Expected 1 jar from Detect Air Gap tool installation at <%s> and did not find any. Check your Jenkins plugin and tool configuration.",
-                            airGapBaseDir
-                    ));
-                }
+                return foundJars[0].toString();
             }
         }
     }


### PR DESCRIPTION
This PR separates out the logic for finding new and old detect jars to remove cognitive complexity resulting from sonarcloud.
