### PR TITLE
Snps (9.0.0) to BD (10.0.0) migration script

### DIFF
--- a/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
+++ b/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
@@ -7,8 +7,8 @@ jenkins = Jenkins.getInstance()
 plugin = jenkins.getPluginManager().getPlugins().find { it.getShortName() == 'blackduck-detect' }
 
 if (plugin == null || !plugin.isActive() || plugin.isOlderThan(new VersionNumber('10.0.0'))) {
-    System.err.println('Version 10.0.0 of Synopsys Detect Jenkins Plugin is either not installed or not activated.')
-    System.err.println('Please install and activate Synopsys Detect Jenkins Plugin version 10.0.0 before running this migration script.')
+    System.err.println('Version 10.0.0 of Black Duck Detect Jenkins Plugin is either not installed or not activated.')
+    System.err.println('Please install and activate Black Duck Detect Jenkins Plugin version 10.0.0 before running this migration script.')
     return
 }
 

--- a/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
+++ b/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
@@ -1,0 +1,90 @@
+import hudson.diagnosis.OldDataMonitor;
+import hudson.util.VersionNumber;
+
+start = System.currentTimeMillis()
+
+jenkins = Jenkins.getInstance()
+plugin = jenkins.getPluginManager().getPlugins().find { it.getShortName() == 'blackduck-detect' }
+println('plugin name: ' + plugin) // blackduck-detect is the name for both 9.0.0 and 10.0.0
+
+if (plugin == null || !plugin.isActive() || plugin.isOlderThan(new VersionNumber('10.0.0'))) {
+    System.err.println('Version 10.0.0 of Synopsys Detect Jenkins Plugin is either not installed or not activated.')
+    System.err.println('Please install and activate Synopsys Detect Jenkins Plugin version 10.0.0 before running this migration script.') // prereq because that's what I've have tested with and 8.0.1 has reached end of support.
+    return
+}
+
+synopsysGlobalConfigXmlPath = new FilePath(jenkins.getRootPath(), 'com.synopsys.integration.jenkins.detect.extensions.global.DetectGlobalConfig.xml')
+blackduckGlobalConfigXmlPath = new FilePath(jenkins.getRootPath(), 'com.blackduck.integration.jenkins.detect.extensions.global.DetectGlobalConfig.xml')
+
+if (synopsysGlobalConfigXmlPath && synopsysGlobalConfigXmlPath.exists()) {
+    println('Found existing Synopsys Detect global configuration.')
+    println('Attempting to migrate Synopsys Detect global configuration... ')
+    try {
+        synopsysGlobalConfig = new XmlSlurper().parse(synopsysGlobalConfigXmlPath.read())
+        println('synopsysGlobalConfig: ' + synopsysGlobalConfig)
+
+        // detectGlobalConfig = com.synopsys.integration.jenkins.detect.PluginHelper.getDetectGlobalConfig() ...... equivalent below vvv
+        detectGlobalConfig = jenkins.model.GlobalConfiguration.all().get(com.blackduck.integration.jenkins.detect.extensions.global.DetectGlobalConfig.class)
+
+        detectGlobalConfig.setBlackDuckUrl(synopsysGlobalConfig.blackDuckUrl.text())
+        detectGlobalConfig.setBlackDuckCredentialsId(synopsysGlobalConfig.blackDuckCredentialsId.text())
+        detectGlobalConfig.setBlackDuckTimeout(Integer.valueOf(synopsysGlobalConfig.blackDuckTimeout.text()))
+        detectGlobalConfig.setTrustBlackDuckCertificates(Boolean.valueOf(synopsysGlobalConfig.trustBlackDuckCertificates.text()))
+        synopsysGlobalConfigXmlPath.delete()
+        print('Migrated global Detect Jenkins Plugin configuration successfully.')
+    } catch (Exception e) {
+        System.err.print("Global Detect Jenkins Plugin configuration migration failed because ${e.getMessage()}.")
+        // Uncomment the following line to debug
+        // e.printStackTrace()
+    }
+    println('')
+}
+
+// Now migrate the job specific configuration
+oldDataMonitor = OldDataMonitor.get(jenkins); // Tracks whether any data structure changes were corrected when loading XML, that could be resaved to migrate that data to the new format.
+items = null
+if (oldDataMonitor != null && oldDataMonitor.isActivated()) {
+    // If possible, we use the OldDataMonitor so we don't have to iterate through all items (jobs, views, etc.)
+    items = oldDataMonitor.getData().keySet()
+} else {
+    // But if that's not available, we fall back to iterating through all items
+    items = jenkins.getItems()
+}
+
+// If performance is an issue, you can comment this line out-- this is just to make the migration output prettier
+items = items.sort{it.getFullName()}
+
+builder = new StringBuilder()
+for (item in items) {
+    // Items can be many things-- only FreeStyle jobs are migratable
+    if (item instanceof FreeStyleProject) {
+        configXml = item.getConfigFile().getFile();
+        synopsysDetectConfig = new XmlSlurper()
+                .parse(configXml)
+                .'**'
+                .find { it.name() == 'com.synopsys.integration.jenkins.detect.extensions.postbuild.DetectPostBuildStep' }
+
+        if (synopsysDetectConfig) {
+            builder.append("Attempting to migrate ${item.getFullName()}... ")
+            try {
+                detectPropertiesToMigrate = synopsysDetectConfig.detectProperties.text()
+                blackDuckDetectConfig = new com.blackduck.integration.jenkins.detect.extensions.postbuild.DetectPostBuildStep(detectPropertiesToMigrate)
+                item.publishersList.add(blackDuckDetectConfig)
+                item.save()
+                builder.append('Migrated FreeStyle job configuration successfully.')
+            } catch (Exception e) {
+                builder.append("Synopsys FreeStyle job configuration migration failed because ${e.getMessage()}.")
+                // Uncomment the following line to debug
+                // e.getStackTrace().each { builder.append(it.toString() + "\r\n") }
+            }
+            builder.append("\r\n")
+        }
+        else {
+            println("Did not find any Synopsys FreeStyle job configurations to migrate.")
+        }
+    }
+}
+println(builder.toString())
+
+end = System.currentTimeMillis()
+println("Migrated in ${end-start}ms")

--- a/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
+++ b/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
@@ -18,7 +18,7 @@ blackduckGlobalConfigXmlPath = new FilePath(jenkins.getRootPath(), 'com.blackduc
 
 if (synopsysGlobalConfigXmlPath && synopsysGlobalConfigXmlPath.exists()) {
     println('Found existing Synopsys Detect global configuration.')
-    println('Attempting to migrate Synopsys Detect global configuration... ')
+    println('Attempting to migrate Synopsys Detect global configuration to Black Duck Detect global configuration... ')
     try {
         synopsysGlobalConfig = new XmlSlurper().parse(synopsysGlobalConfigXmlPath.read())
 

--- a/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
+++ b/groovy-scripts/migrate_9_0_0_to_10_0_0.groovy
@@ -17,8 +17,8 @@ synopsysGlobalConfigXmlPath = new FilePath(jenkins.getRootPath(), 'com.synopsys.
 blackduckGlobalConfigXmlPath = new FilePath(jenkins.getRootPath(), 'com.blackduck.integration.jenkins.detect.extensions.global.DetectGlobalConfig.xml')
 
 if (synopsysGlobalConfigXmlPath && synopsysGlobalConfigXmlPath.exists()) {
-    println('Found existing Synopsys Detect global configuration.')
-    println('Attempting to migrate Synopsys Detect global configuration... ')
+    println('Found existing Synopsys Detect system configuration.')
+    println('Attempting to migrate Synopsys Detect system configuration... ')
     try {
         synopsysGlobalConfig = new XmlSlurper().parse(synopsysGlobalConfigXmlPath.read())
         println('synopsysGlobalConfig: ' + synopsysGlobalConfig)
@@ -33,7 +33,7 @@ if (synopsysGlobalConfigXmlPath && synopsysGlobalConfigXmlPath.exists()) {
         synopsysGlobalConfigXmlPath.delete()
         print('Migrated global Detect Jenkins Plugin configuration successfully.')
     } catch (Exception e) {
-        System.err.print("Global Detect Jenkins Plugin configuration migration failed because ${e.getMessage()}.")
+        System.err.print("Detect Jenkins Plugin system configuration migration failed because ${e.getMessage()}.")
         // Uncomment the following line to debug
         // e.printStackTrace()
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
IDTCTJNKNS-282
When users upgrade from version 9.0.0 (Synopsys Detect) to 10.0.0 (BD Detect) of the Detect Jenkins Plugin, existing configurations will not be applied to the "new" plugin. This includes global system configurations such as the BD URL and access token, etc. as well as FreeStyle job configurations that are _per_ scan (project name, version, etc). For users that run a Detect scan as a post-build action in a number of Freestyle jobs, running this script will migrate those settings over so they do not have to do it manually. 

### Testing done
The migration script was tested for an upgrade from version 9.0.0 to 10.0.0 of the plugin. Version 8.0.1 or earlier were not tested with as those have reached end of support. 

Jenkins versions tested with: 
- 2.426.3
- 2.479.3-lts
- 2.479.3

Testing steps: 
1. Run the appropriate version of Jenkins in Docker locally 
2. Install blackduck-detect-9.0.0.hpi 
3. Configure global system settings for Synopsys Detect
![Screenshot 2025-01-14 at 03 12 30](https://github.com/user-attachments/assets/b3ec8445-50a6-4e54-9266-b8cd5eba5d42)
4. Create two test FreeStyle jobs and configure Detect as a post-build step for both
6. Confirm Detect v9.10.1 scan is run with all configured properties (BD URL, project name, etc)
7. Download and install available Detect Jenkins Plugin update to 10.0.0 (restart Jenkins for changes to take effect)
![Screenshot 2025-01-14 at 03 13 45](https://github.com/user-attachments/assets/54035885-982f-441d-9583-9419723f9ccc)
8. Confirm system settings are now blank as anticipated and pipelines are all messed up.
9. Run migration script 
![Screenshot 2025-01-14 at 03 19 17](https://github.com/user-attachments/assets/6270603c-deec-4e34-a138-9a19268aadef)
10. Confirm global setting have been updated
![Screenshot 2025-01-14 at 03 20 27](https://github.com/user-attachments/assets/43112cc1-c556-427b-8369-19a34772157f)
11. Confirm the two jobs from step 5 successfully run a Detect v10.1.0 scan following migration

When configuring FreeStyle jobs, users input a number of Detect properties. I checked any property name changes post Sierra and did not discover any properties that would be problematic during the migration (aka that use the term "synopsys"). We only have logging.level.com.synopsys.integration, which has already been removed.

We have done something almost identical in the past (6 years ago when black duck --> synopsys), here is that old script: https://github.com/jenkinsci/synopsys-detect-plugin/tree/master/groovy-scripts