### PR TITLE
chore(security EU CRA): additional CVE remediations - plexus-utils, jackson, commons-beanutils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,9 @@ configurations.all {
     resolutionStrategy.force 'com.blackduck.integration:integration-common:27.0.4'
     // CVE fix: jackson-core 2.14.0 (via zjsonpatch->integration-common) has known CVEs;
     // all three Jackson artifacts must stay in sync
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.18.8'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.18.8'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.18.8'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.22.1'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.22'
     // CVE fix: plexus-utils 4.0.0 (from plexus-archiver) has known CVEs; 4.0.3 is the patch release
     resolutionStrategy.force 'org.codehaus.plexus:plexus-utils:4.0.3'
     // CVE fix: commons-beanutils 1.9.4 (from jenkins-core via stapler/json-lib/commons-jelly) has known CVEs;

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ buildscript {
             resolutionStrategy.force 'org.jenkins-ci.main:jenkins-test-harness:2110.v71145c2d8157'
             resolutionStrategy.force 'org.apache.ant:ant:1.10.4'
             resolutionStrategy.force 'org.codehaus.plexus:plexus-archiver:4.8.0'
+            // CVE fix: plexus-utils 4.0.0 (from plexus-archiver) has known CVEs; 4.0.3 is the patch release
+            resolutionStrategy.force 'org.codehaus.plexus:plexus-utils:4.0.3'
         }
     }
 }
@@ -40,6 +42,11 @@ configurations.all {
     resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.18.8'
     resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.18.8'
     resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.18.8'
+    // CVE fix: plexus-utils 4.0.0 (from plexus-archiver) has known CVEs; 4.0.3 is the patch release
+    resolutionStrategy.force 'org.codehaus.plexus:plexus-utils:4.0.3'
+    // CVE fix: commons-beanutils 1.9.4 (from jenkins-core via stapler/json-lib/commons-jelly) has known CVEs;
+    // 1.11.0 fixes it; force makes it definitive across all configurations
+    resolutionStrategy.force 'commons-beanutils:commons-beanutils:1.11.0'
 }
 
 def internalRepoHost = System.getenv("SNPS_INTERNAL_ARTIFACTORY")


### PR DESCRIPTION
Additional CVE fixes on top of the previous remediation pass.

- Force plexus-utils:4.0.3 in both buildscript and main configurations — 4.0.0 (from plexus-archiver) has known CVEs; forced in both blocks since plexus-archiver is used in build toolchain and main scopes
- Bump Jackson 2.18.8 -> 2.22.1 (jackson-core, jackson-databind) and 2.22 (jackson-annotations) — all three kept in sync; 2.22.x is the latest available
- Force commons-beanutils:1.11.0 — 1.9.4 declared by jenkins-core via stapler, json-lib, commons-jelly; 1.11.0 fixes the CVE; force makes it definitive across all configurations where plexus-archiver is not in scope